### PR TITLE
vsm-cli can use https urls

### DIFF
--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -76,7 +76,18 @@ func apiLogin(username string, privateKey *rsa.PrivateKey) (string, error) {
 	}
 
 	loginUrl := fmt.Sprintf("%v/login", Url)
-	resp, err := http.Post(loginUrl, "application/json", body)
+	req, err := http.NewRequest("POST", loginUrl, body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client, err := httpClient()
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -114,7 +125,13 @@ func apiLogin(username string, privateKey *rsa.PrivateKey) (string, error) {
 		return "", err
 	}
 
-	resp, err = http.Post(loginUrl, "application/json", body)
+	req, err = http.NewRequest("POST", loginUrl, body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = client.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -3,7 +3,13 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vmware/virtual-security-module/server"
@@ -18,9 +24,39 @@ For more information visit https://github.com/vmware/virtual-security-module.`,
 	}
 	Url   string = ""
 	Token string = ""
+	Cert  string = ""
 )
 
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&Url, "url", "u", fmt.Sprintf("http://localhost:%v", server.DefaultHttpPort), "server URL")
 	RootCmd.PersistentFlags().StringVarP(&Token, "token", "t", "", "auth token")
+	RootCmd.PersistentFlags().StringVarP(&Cert, "cert", "c", "certs/test-root-cert.pem", "root CA certificate filename")
+}
+
+func httpClient() (*http.Client, error) {
+	u, err := url.Parse(Url)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.EqualFold(u.Scheme, "https") {
+		rootCertPEM, err := ioutil.ReadFile(Cert)
+		if err != nil {
+			return nil, err
+		}
+
+		certPool := x509.NewCertPool()
+		ok := certPool.AppendCertsFromPEM(rootCertPEM)
+		if !ok {
+			return nil, fmt.Errorf("failed to add certificate from %v to trust chain", Cert)
+		}
+
+		return &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: certPool},
+			},
+		}, nil
+	}
+
+	return http.DefaultClient, nil
 }

--- a/cli/cmd/secrets.go
+++ b/cli/cmd/secrets.go
@@ -166,7 +166,12 @@ func apiCreateSecret(secretId, secretData string) (string, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", Token))
 
-	resp, err := http.DefaultClient.Do(req)
+	client, err := httpClient()
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -199,7 +204,12 @@ func apiDeleteSecret(secretId string) error {
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", Token))
 
-	resp, err := http.DefaultClient.Do(req)
+	client, err := httpClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -223,7 +233,13 @@ func apiGetSecret(secretId string) (*model.SecretEntry, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", Token))
-	resp, err := http.DefaultClient.Do(req)
+
+	client, err := httpClient()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/users.go
+++ b/cli/cmd/users.go
@@ -176,7 +176,12 @@ func apiCreateUser(username string, pubKey *rsa.PublicKey) (string, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", Token))
 
-	resp, err := http.DefaultClient.Do(req)
+	client, err := httpClient()
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -209,7 +214,12 @@ func apiDeleteUser(username string) error {
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", Token))
 
-	resp, err := http.DefaultClient.Do(req)
+	client, err := httpClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -233,7 +243,12 @@ func apiGetUser(username string) (*model.UserEntry, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", Token))
-	resp, err := http.DefaultClient.Do(req)
+	client, err := httpClient()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -253,7 +253,7 @@ func (server *Server) ListenAndServe() error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			fmt.Printf("Listening on %v\n", addr)
+			fmt.Printf("(http) Listening on %v\n", addr)
 			log.Fatal(server.httpServer.ListenAndServe())
 		}()
 	}
@@ -264,8 +264,8 @@ func (server *Server) ListenAndServe() error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			fmt.Printf("Listening on %v\n", addr)
-			log.Fatal(server.httpsServer.ListenAndServeTLS(server.tlsConfig.caCertFile, server.tlsConfig.caKeyFile))
+			fmt.Printf("(https) Listening on %v\n", addr)
+			log.Fatal(server.httpsServer.ListenAndServeTLS(server.tlsConfig.serverCertFile, server.tlsConfig.serverKeyFile))
 		}()
 	}
 


### PR DESCRIPTION
vsm-cli can now use https urls (like https://localhost:8443):

* A new --cert, -c top-level cli flag has been introduced: if provided, it
  is expected to be the filename containing a public certificate of a root
  CA that the cli client should trust. If the server url's scheme is https,
  and a cert is not provided by the client, then the default would be
  "certs/test-root-cert.pem" (so that https works out-of-box with the test
  certificates).
* All cli commands have been updated and tested to work with https.