### PR TITLE
Removed need to use -B in "make doc"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 pkg/
 dist/
 bin/
+.project

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ DOC := $(DOC_DIR)/swagger.json
 GO_ENV := GOPATH=$(GOPATH)
 GO := $(GO_ENV) go
 
+.PHONY: doc
 default: build
 
 install-deps:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ make test
 ```
 7. To generate RESTful API docs run:
 ```
-make -B doc
+make doc
 ```
 8. To start the server run:
 ```

--- a/doc/HOWTO.md
+++ b/doc/HOWTO.md
@@ -77,7 +77,7 @@ If the server, "vsmd", is already built, you can start it
 The server supports a RESTful API, which is documented using
 [Swagger](http://swagger.io/). The server's swagger specification file is
 **"swagger.json"**, which resides in the "doc" dir (if it's not there, you
-need to generate it using "make -B doc"). There are multiple tools for loading
+need to generate it using "make doc"). There are multiple tools for loading
 and browsing a Swagger spec; we've successfully tested the procedure described
 at http://swagger.io/docs/ (look for "Swagger UI Documentation"), as follows:
 

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "Secret Lifecycle Management API",
+    "description": "Namespace API",
     "title": "Virtual Security Module"
   },
   "basePath": "/",


### PR DESCRIPTION
Fixed Makefile so there's not need to use -B to update API docs.
Updated documentation as well.

Signed-off-by: asafka <kariva@vmware.com>