### PR TITLE
Persistent Key Store Adapter using Bolt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ install-deps:
 	$(GO) get -u github.com/dgrijalva/jwt-go
 	$(GO) get -u github.com/spf13/cobra/cobra
 	$(GO) get -u gopkg.in/mgo.v2
+	$(GO) get -u github.com/boltdb/bolt/...
 	$(GO) get -u github.com/golang/lint/golint
 	
 build: fmt vet

--- a/authn/builtin_provider.go
+++ b/authn/builtin_provider.go
@@ -203,7 +203,7 @@ func (p *BuiltinProvider) CreateUser(userEntry *model.UserEntry) (string, error)
 	}
 
 	// persist key using virtual key store
-	if err := p.keyStore.Write(userpath, key); err != nil {
+	if err := p.keyStore.Create(userpath, key); err != nil {
 		return "", err
 	}
 

--- a/authn/builtin_provider_test.go
+++ b/authn/builtin_provider_test.go
@@ -21,7 +21,7 @@ var p *BuiltinProvider
 
 func builtinProviderTestSetup() {
 	p = NewBuiltinProvider()
-	if err := p.Init(nil, vds.NewInMemoryDS(), vks.New()); err != nil {
+	if err := p.Init(nil, vds.NewInMemoryDS(), vks.NewInMemoryKS()); err != nil {
 		fmt.Printf("Failed to initialize builtin provider: %v\n", err)
 		os.Exit(1)
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -13,5 +13,7 @@ server:
   rootInitPriKey: certs/test-root-init-private.pem
 dataStore:
   type: InMemoryDataStore
+  connectionString:
 keyStore:
   type: InMemoryKeyStore
+  connectionString:

--- a/config/config.go
+++ b/config/config.go
@@ -37,5 +37,6 @@ type DataStoreConfig struct {
 }
 
 type KeyStoreConfig struct {
-	StoreType string `yaml:"type"`
+	StoreType        string `yaml:"type"`
+	ConnectionString string `yaml:"connectionString"`
 }

--- a/secret/data_st.go
+++ b/secret/data_st.go
@@ -79,7 +79,7 @@ func (dataST *DataSecretType) CreateSecret(ctx gocontext.Context, secretEntry *m
 	}
 
 	// persist key using virtual key store
-	if err := dataST.keyStore.Write(secretPath, key); err != nil {
+	if err := dataST.keyStore.Create(secretPath, key); err != nil {
 		return "", err
 	}
 

--- a/secret/rsa_private_key_st.go
+++ b/secret/rsa_private_key_st.go
@@ -109,7 +109,7 @@ func (rsaPrivKeyST *RSAPrivateKeySecretType) CreateSecret(ctx gocontext.Context,
 
 	// persist key using virtual key store
 	secretPath := vds.SecretIdToPath(secretEntry.Id)
-	if err := rsaPrivKeyST.keyStore.Write(secretPath, key); err != nil {
+	if err := rsaPrivKeyST.keyStore.Create(secretPath, key); err != nil {
 		return "", err
 	}
 

--- a/secret/x509_certificate_st.go
+++ b/secret/x509_certificate_st.go
@@ -106,7 +106,7 @@ func (certST *X509CertificateSecretType) CreateSecret(ctx gocontext.Context, sec
 
 	// persist key using virtual key store
 	secretPath := vds.SecretIdToPath(secretEntry.Id)
-	if err := certST.keyStore.Write(secretPath, key); err != nil {
+	if err := certST.keyStore.Create(secretPath, key); err != nil {
 		return "", err
 	}
 

--- a/vds/inmemory_ds_test.go
+++ b/vds/inmemory_ds_test.go
@@ -1,0 +1,121 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package vds
+
+import (
+	"testing"
+
+	"github.com/vmware/virtual-security-module/config"
+	"reflect"
+)
+
+var inMemoryDS *InMemoryDS
+
+func inMemoryDSTestSetup() {
+	tCfg := config.GenerateTestConfig()
+	tCfg.DataStoreConfig.StoreType = inMemoryDSType
+
+	inMemoryDS = NewInMemoryDS()
+	inMemoryDS.Init(tCfg)
+}
+
+func inMemoryDSTestCleanup() {
+}
+
+func TestInMemoryDSCreateAndGet(t *testing.T) {
+	id := "id1"
+
+	dsEntry := &DataStoreEntry{
+		Id:       id,
+		Data:     []byte("data1"),
+		MetaData: "metadata1",
+	}
+
+	if err := inMemoryDS.CreateEntry(dsEntry); err != nil {
+		t.Fatalf("Failed to create entry: %v", err)
+	}
+
+	dsEntry2, err := inMemoryDS.ReadEntry(id)
+	if err != nil {
+		t.Fatalf("Failed to read entry: %v", err)
+	}
+
+	if !reflect.DeepEqual(dsEntry, dsEntry2) {
+		t.Fatalf("Retreived value is different than expected")
+	}
+
+	if err := inMemoryDS.DeleteEntry(id); err != nil {
+		t.Fatalf("Failed to delete entry: %v", err)
+	}
+}
+
+func TestInMemoryCreateDuplicate(t *testing.T) {
+	id := "id1"
+
+	dsEntry := &DataStoreEntry{
+		Id:       id,
+		Data:     []byte("data1"),
+		MetaData: "metadata1",
+	}
+
+	if err := inMemoryDS.CreateEntry(dsEntry); err != nil {
+		t.Fatalf("Failed to create entry: %v", err)
+	}
+
+	if err := inMemoryDS.CreateEntry(dsEntry); err == nil {
+		t.Fatalf("Succeeded to create entry with an existing id")
+	}
+
+	if err := inMemoryDS.DeleteEntry(id); err != nil {
+		t.Fatalf("Failed to delete entry: %v", err)
+	}
+}
+
+func TestInMemoryGetNonExistent(t *testing.T) {
+	_, err := inMemoryDS.ReadEntry("non-existent-id")
+	if err == nil {
+		t.Fatalf("Succeeded to read entry with non-exietent id")
+	}
+}
+
+func TestInMemoryDeleteNonExistent(t *testing.T) {
+	err := inMemoryDS.DeleteEntry("non-existent-id")
+	if err == nil {
+		t.Fatalf("Succeeded to delete entry with non-exietent id")
+	}
+}
+
+func TestInMemoryDSRecreateAfterDelete(t *testing.T) {
+	id := "id1"
+
+	dsEntry := &DataStoreEntry{
+		Id:       id,
+		Data:     []byte("data1"),
+		MetaData: "metadata1",
+	}
+
+	if err := inMemoryDS.CreateEntry(dsEntry); err != nil {
+		t.Fatalf("Failed to create entry: %v", err)
+	}
+
+	if err := inMemoryDS.DeleteEntry(id); err != nil {
+		t.Fatalf("Failed to delete entry: %v", err)
+	}
+
+	if err := inMemoryDS.CreateEntry(dsEntry); err != nil {
+		t.Fatalf("Failed to create entry: %v", err)
+	}
+
+	dsEntry2, err := inMemoryDS.ReadEntry(id)
+	if err != nil {
+		t.Fatalf("Failed to read entry: %v", err)
+	}
+
+	if !reflect.DeepEqual(dsEntry, dsEntry2) {
+		t.Fatalf("Retreived value is different than expected")
+	}
+
+	if err := inMemoryDS.DeleteEntry(id); err != nil {
+		t.Fatalf("Failed to delete entry: %v", err)
+	}
+}

--- a/vds/mongodb_ds.go
+++ b/vds/mongodb_ds.go
@@ -65,7 +65,7 @@ func (ds *MongoDBDS) CreateEntry(entry *DataStoreEntry) error {
 	doc := translateToMongoDocument(entry)
 	err := collection.Insert(doc)
 	if err != nil {
-		return translateError(err)
+		return translateMongoError(err)
 	}
 
 	return nil
@@ -79,7 +79,7 @@ func (ds *MongoDBDS) ReadEntry(entryId string) (*DataStoreEntry, error) {
 	err := collection.Find(bson.M{"_id": entryId}).One(&doc)
 
 	if err != nil {
-		return nil, translateError(err)
+		return nil, translateMongoError(err)
 	}
 
 	dsEntry, err := translatefromMongoDocument(&doc)
@@ -96,7 +96,7 @@ func (ds *MongoDBDS) DeleteEntry(entryId string) error {
 
 	err := collection.Remove(bson.M{"_id": entryId})
 	if err != nil {
-		return translateError(err)
+		return translateMongoError(err)
 	}
 
 	return err
@@ -116,7 +116,7 @@ func (ds *MongoDBDS) SearchChildEntries(parentEntryId string) ([]*DataStoreEntry
 	err := collection.Find(bson.M{"_id": bson.M{"$regex": bson.RegEx{Pattern: pattern}}}).All(&docs)
 
 	if err != nil {
-		return []*DataStoreEntry{}, translateError(err)
+		return []*DataStoreEntry{}, translateMongoError(err)
 	}
 
 	dsEntries := make([]*DataStoreEntry, 0, len(docs))
@@ -181,7 +181,7 @@ func translatefromMongoDocument(mongoDoc *bson.M) (*DataStoreEntry, error) {
 	}, nil
 }
 
-func translateError(mongoError error) error {
+func translateMongoError(mongoError error) error {
 	switch mongoError {
 	case mgo.ErrNotFound:
 		return util.ErrNotFound

--- a/vds/vds_test.go
+++ b/vds/vds_test.go
@@ -1,0 +1,18 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package vds
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	inMemoryDSTestSetup()
+
+	exitCode := m.Run()
+
+	inMemoryDSTestCleanup()
+
+	os.Exit(exitCode)
+}

--- a/vks/bolt_ks.go
+++ b/vks/bolt_ks.go
@@ -1,0 +1,138 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package vks
+
+import (
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	"github.com/vmware/virtual-security-module/config"
+	"github.com/vmware/virtual-security-module/util"
+)
+
+const (
+	boltKSType = "BoltKeyStore"
+	vsmBucket  = "VSM"
+)
+
+func init() {
+	if err := KeyStoreRegistrar.Register(boltKSType, NewBoltKS()); err != nil {
+		panic(fmt.Sprintf("Failed to register key store type %v: %v", boltKSType, err))
+	}
+}
+
+// An implementation of a keystore using Bolt (https://github.com/boltdb/bolt)
+type BoltKS struct {
+	db       *bolt.DB
+	location string
+}
+
+func NewBoltKS() *BoltKS {
+	return &BoltKS{}
+}
+
+func (ks *BoltKS) Init(cfg *config.Config) error {
+	connectionString := cfg.KeyStoreConfig.ConnectionString
+	if connectionString == "" {
+		return util.ErrBadConfig
+	}
+
+	db, err := bolt.Open(connectionString, 0600, nil)
+	if err != nil {
+		return err
+	}
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(vsmBucket))
+		if err != nil {
+			return translateBoltError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return translateBoltError(err)
+	}
+
+	ks.db = db
+	ks.location = connectionString
+
+	return nil
+}
+
+func (ks *BoltKS) CompleteInit(*config.Config) error {
+	return nil
+}
+
+func (ks *BoltKS) Initialized() bool {
+	return ks.db != nil
+}
+
+func (ks *BoltKS) Create(alias string, key []byte) error {
+	err := ks.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(vsmBucket))
+		aliasBytes := []byte(alias)
+		v := bucket.Get(aliasBytes)
+		if v != nil {
+			return util.ErrAlreadyExists
+		}
+
+		return bucket.Put(aliasBytes, key)
+	})
+	if err != nil {
+		return translateBoltError(err)
+	}
+
+	return nil
+}
+
+func (ks *BoltKS) Read(alias string) ([]byte, error) {
+	var result []byte
+
+	err := ks.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(vsmBucket))
+		v := bucket.Get([]byte(alias))
+		if v == nil {
+			return util.ErrNotFound
+		}
+
+		result = make([]byte, len(v))
+		copy(result, v)
+
+		return nil
+	})
+	if err != nil {
+		return []byte{}, translateBoltError(err)
+	}
+
+	return result, nil
+}
+
+func (ks *BoltKS) Delete(alias string) error {
+	err := ks.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(vsmBucket))
+		aliasBytes := []byte(alias)
+		v := bucket.Get(aliasBytes)
+		if v == nil {
+			return util.ErrNotFound
+		}
+
+		return bucket.Delete(aliasBytes)
+	})
+	if err != nil {
+		return translateBoltError(err)
+	}
+
+	return nil
+}
+
+func (ks *BoltKS) Type() string {
+	return boltKSType
+}
+
+func (ks *BoltKS) Location() string {
+	return ""
+}
+
+func translateBoltError(boltError error) error {
+	return boltError
+}

--- a/vks/bolt_ks_test.go
+++ b/vks/bolt_ks_test.go
@@ -1,0 +1,115 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package vks
+
+import (
+	"os"
+	"testing"
+
+	"bytes"
+	"github.com/vmware/virtual-security-module/config"
+)
+
+const testdbFilename = "testBoltKS.db"
+
+var boltKS *BoltKS
+
+func boltKSTestSetup() {
+	tCfg := config.GenerateTestConfig()
+	tCfg.KeyStoreConfig.StoreType = boltKSType
+	tCfg.KeyStoreConfig.ConnectionString = testdbFilename
+
+	boltKS = NewBoltKS()
+	boltKS.Init(tCfg)
+}
+
+func boltKSTestCleanup() {
+	os.Remove(testdbFilename)
+}
+
+func TestBoltKSCreateAndGet(t *testing.T) {
+	alias := "alias1"
+	val := []byte("val1")
+
+	if err := boltKS.Create(alias, val); err != nil {
+		t.Fatalf("Failed to create alias %s: %v", alias, err)
+	}
+
+	val2, err := boltKS.Read(alias)
+	if err != nil {
+		t.Fatalf("Failed to read alias %s: %v", alias, err)
+	}
+
+	if !bytes.Equal(val, val2) {
+		t.Fatalf("Retreived value %s is different than expected", string(val2))
+	}
+
+	if err := boltKS.Delete(alias); err != nil {
+		t.Fatalf("Failed to delete alias %s: %v", alias, err)
+	}
+}
+
+func TestBoltCreateDuplicate(t *testing.T) {
+	alias := "alias1"
+	val := []byte("val1")
+
+	if err := boltKS.Create(alias, val); err != nil {
+		t.Fatalf("Failed to create alias %s: %v", alias, err)
+	}
+
+	if err := boltKS.Create(alias, val); err == nil {
+		t.Fatalf("Succeeded to create the same alias twice")
+	}
+
+	if err := boltKS.Delete(alias); err != nil {
+		t.Fatalf("Failed to delete alias %s: %v", alias, err)
+	}
+}
+
+func TestBoltGetNonExistent(t *testing.T) {
+	alias := "alias1"
+
+	_, err := boltKS.Read(alias)
+	if err == nil {
+		t.Fatalf("Succeeded to read a non-existing alias")
+	}
+}
+
+func TestBoltDeleteNonExistent(t *testing.T) {
+	alias := "alias1"
+
+	err := boltKS.Delete(alias)
+	if err == nil {
+		t.Fatalf("Succeeded to delete a non-existing alias")
+	}
+}
+
+func TestBoltKSRecreateAfterDelete(t *testing.T) {
+	alias := "alias1"
+	val := []byte("val1")
+
+	if err := boltKS.Create(alias, val); err != nil {
+		t.Fatalf("Failed to create alias %s: %v", alias, err)
+	}
+
+	if err := boltKS.Delete(alias); err != nil {
+		t.Fatalf("Failed to delete alias %s: %v", alias, err)
+	}
+
+	if err := boltKS.Create(alias, val); err != nil {
+		t.Fatalf("Failed to create alias %s: %v", alias, err)
+	}
+
+	val2, err := boltKS.Read(alias)
+	if err != nil {
+		t.Fatalf("Failed to read alias %s: %v", alias, err)
+	}
+
+	if !bytes.Equal(val, val2) {
+		t.Fatalf("Retreived value %s is different than expected", string(val2))
+	}
+
+	if err := boltKS.Delete(alias); err != nil {
+		t.Fatalf("Failed to delete alias %s: %v", alias, err)
+	}
+}

--- a/vks/inmemory_ks_test.go
+++ b/vks/inmemory_ks_test.go
@@ -1,0 +1,110 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package vks
+
+import (
+	"testing"
+
+	"bytes"
+	"github.com/vmware/virtual-security-module/config"
+)
+
+var inMemoryKS *InMemoryKS
+
+func inMemoryKSTestSetup() {
+	tCfg := config.GenerateTestConfig()
+	tCfg.KeyStoreConfig.StoreType = inMemoryKSType
+
+	inMemoryKS = NewInMemoryKS()
+	inMemoryKS.Init(tCfg)
+}
+
+func inMemoryKSTestCleanup() {
+}
+
+func TestInMemoryKSCreateAndGet(t *testing.T) {
+	alias := "alias1"
+	val := []byte("val1")
+
+	if err := inMemoryKS.Create(alias, val); err != nil {
+		t.Fatalf("Failed to create alias %s: %v", alias, err)
+	}
+
+	val2, err := inMemoryKS.Read(alias)
+	if err != nil {
+		t.Fatalf("Failed to read alias %s: %v", alias, err)
+	}
+
+	if !bytes.Equal(val, val2) {
+		t.Fatalf("Retreived value %s is different than expected", string(val2))
+	}
+
+	if err := inMemoryKS.Delete(alias); err != nil {
+		t.Fatalf("Failed to delete alias %s: %v", alias, err)
+	}
+}
+
+func TestInMemoryCreateDuplicate(t *testing.T) {
+	alias := "alias1"
+	val := []byte("val1")
+
+	if err := inMemoryKS.Create(alias, val); err != nil {
+		t.Fatalf("Failed to create alias %s: %v", alias, err)
+	}
+
+	if err := inMemoryKS.Create(alias, val); err == nil {
+		t.Fatalf("Succeeded to create the same alias twice")
+	}
+
+	if err := inMemoryKS.Delete(alias); err != nil {
+		t.Fatalf("Failed to delete alias %s: %v", alias, err)
+	}
+}
+
+func TestInMemoryGetNonExistent(t *testing.T) {
+	alias := "alias1"
+
+	_, err := inMemoryKS.Read(alias)
+	if err == nil {
+		t.Fatalf("Succeeded to read a non-existing alias")
+	}
+}
+
+func TestInMemoryDeleteNonExistent(t *testing.T) {
+	alias := "alias1"
+
+	err := inMemoryKS.Delete(alias)
+	if err == nil {
+		t.Fatalf("Succeeded to delete a non-existing alias")
+	}
+}
+
+func TestInMemoryKSRecreateAfterDelete(t *testing.T) {
+	alias := "alias1"
+	val := []byte("val1")
+
+	if err := inMemoryKS.Create(alias, val); err != nil {
+		t.Fatalf("Failed to create alias %s: %v", alias, err)
+	}
+
+	if err := inMemoryKS.Delete(alias); err != nil {
+		t.Fatalf("Failed to delete alias %s: %v", alias, err)
+	}
+
+	if err := inMemoryKS.Create(alias, val); err != nil {
+		t.Fatalf("Failed to create alias %s: %v", alias, err)
+	}
+
+	val2, err := inMemoryKS.Read(alias)
+	if err != nil {
+		t.Fatalf("Failed to read alias %s: %v", alias, err)
+	}
+
+	if !bytes.Equal(val, val2) {
+		t.Fatalf("Retreived value %s is different than expected", string(val2))
+	}
+
+	if err := inMemoryKS.Delete(alias); err != nil {
+		t.Fatalf("Failed to delete alias %s: %v", alias, err)
+	}
+}

--- a/vks/keystore_adapter.go
+++ b/vks/keystore_adapter.go
@@ -16,7 +16,7 @@ type KeyStoreAdapter interface {
 	CompleteInit(*config.Config) error
 	Initialized() bool
 
-	Write(alias string, key []byte) error
+	Create(alias string, key []byte) error
 	Read(alias string) ([]byte, error)
 	Delete(alias string) error
 

--- a/vks/vks_test.go
+++ b/vks/vks_test.go
@@ -1,0 +1,20 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package vks
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	inMemoryKSTestSetup()
+	boltKSTestSetup()
+
+	exitCode := m.Run()
+
+	inMemoryKSTestCleanup()
+	boltKSTestCleanup()
+
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
Implementation of a persistent Key Store Adapter using Bolt
(https://github.com/boltdb/bolt).

To use, make the following modifications in cofig.yaml/keyStore:
* Set type to BoltKeyStore
* Set connectionString to some filename (e.g. ks.db)

Signed-off-by: asafka <kariva@vmware.com>