### PR TITLE
CassandraStorageAdapter multi-dc support

### DIFF
--- a/doc/HOWTO.md
+++ b/doc/HOWTO.md
@@ -577,6 +577,15 @@ CREATE TABLE vsm.vsm_entries (id text PRIMARY KEY, parent_id text, data blob, me
 
 This will create the vsm keyspace and its vsm_entries table in Cassandra.
 
+The CassandraDataStore adapter suppors more advanced settings:
+* You can filter the datacenter of hosts to connect to using the "datacenter" attribute in the connection string
+* You can set the consistency level of operations using the "consistency" attribute in the connection string
+
+For example:
+```
+connectionString: 192.168.211.138;datacenter=uswest;consistency=LOCAL_QUORUM
+```
+
 
 Now let's continue to the Key Store Adapters. VSM supports any key store that satisfies the KeyStoreAdapter interface.
 The only implementation currently available (beyond the in-memory one), is "BoltKeyStore", which is an adapter based

--- a/secret/secret_api.go
+++ b/secret/secret_api.go
@@ -37,6 +37,7 @@ func (secretManager *SecretManager) RegisterEndpoints(mux *denco.Mux) []denco.Ha
 
 		id, err := secretManager.CreateSecret(r.Context(), secretEntry)
 		if err != nil {
+			log.Printf("Error: %s\n", err.Error())
 			if e := util.WriteErrorResponse(w, err); e != nil {
 				log.Printf("failed to write error response: %v\n", e)
 			}
@@ -66,6 +67,7 @@ func (secretManager *SecretManager) RegisterEndpoints(mux *denco.Mux) []denco.Ha
 
 		secretEntry, err := secretManager.GetSecret(r.Context(), secretPath)
 		if err != nil {
+			log.Printf("Error: %s\n", err.Error())
 			if e := util.WriteErrorResponse(w, err); e != nil {
 				log.Printf("failed to write error response: %v\n", e)
 			}
@@ -94,6 +96,7 @@ func (secretManager *SecretManager) RegisterEndpoints(mux *denco.Mux) []denco.Ha
 		}
 
 		if err := secretManager.DeleteSecret(r.Context(), secretPath); err != nil {
+			log.Printf("Error: %s\n", err.Error())
 			util.WriteErrorStatus(w, err)
 			return
 		}


### PR DESCRIPTION
Added the following capabilities to the CassandraStorageAdapter:
* The ability to specify the hosts' datacenter to connect to
* The ability to specify operations' consistency level

Documentation has been updated.

Signed-off-by: asafka <kariva@vmware.com>